### PR TITLE
etree and AtomicString have moved to markdown.util

### DIFF
--- a/urlize.py
+++ b/urlize.py
@@ -61,9 +61,9 @@ class UrlizePattern(markdown.inlinepatterns.Pattern):
             else:
                 url = 'http://' + url
     
-        el = markdown.etree.Element("a")
+        el = markdown.util.etree.Element("a")
         el.set('href', url)
-        el.text = markdown.AtomicString(text)
+        el.text = markdown.util.AtomicString(text)
         return el
 
 class UrlizeExtension(markdown.Extension):


### PR DESCRIPTION
Updating for the latest version of markdown
