### PR TITLE
Fixed plugin loading in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Once installed, you can use it in a Django template like this:
 Or in Python code like this:
 
     import markdown  
-    md = markdown.Markdown(safe_mode=True, extensions=['urlize'])  
+    md = markdown.Markdown(safe_mode=True, extensions=['urlize:UrlizeExtension'])  
     converted_text = md.convert(text)  
 
 Here is the start of the [Markdown extension docs](http://www.freewisdom.org/projects/python-markdown/Extensions) in case you need more info.


### PR DESCRIPTION
The extension fails to load if the module is not named `mdx_*` or the extension is loaded as `module:ExtensionSubclass`. Just lost an hour. :stuck_out_tongue:
