### PR TITLE
Use args and kwargs when instantiating the extension, as configs key is ...

### DIFF
--- a/mdx_urlize.py
+++ b/mdx_urlize.py
@@ -73,8 +73,8 @@ class UrlizeExtension(markdown.Extension):
         """ Replace autolink with UrlizePattern """
         md.inlinePatterns['autolink'] = UrlizePattern(URLIZE_RE, md)
 
-def makeExtension(configs=None):
-    return UrlizeExtension(configs=configs)
+def makeExtension(*args, **kwargs):
+    return UrlizeExtension(*args, **kwargs)
 
 if __name__ == "__main__":
     import doctest


### PR DESCRIPTION
Use args and kwargs when instantiating the extension, as configs key is no longer supported.