### PR TITLE
Compatibility with python-markdown 3.4

### DIFF
--- a/mdx_urlize.py
+++ b/mdx_urlize.py
@@ -36,6 +36,7 @@ u'<p>del.icio.us</p>'
 """
 
 import markdown
+from xml.etree import ElementTree
 
 # Global Vars
 URLIZE_RE = '(%s)' % '|'.join([
@@ -61,7 +62,7 @@ class UrlizePattern(markdown.inlinepatterns.Pattern):
             else:
                 url = 'http://' + url
     
-        el = markdown.util.etree.Element("a")
+        el = ElementTree.Element("a")
         el.set('href', url)
         el.text = markdown.util.AtomicString(text)
         return el
@@ -69,12 +70,12 @@ class UrlizePattern(markdown.inlinepatterns.Pattern):
 class UrlizeExtension(markdown.Extension):
     """ Urlize Extension for Python-Markdown. """
 
-    def extendMarkdown(self, md, md_globals):
+    def extendMarkdown(self, md):
         """ Replace autolink with UrlizePattern """
-        md.inlinePatterns['autolink'] = UrlizePattern(URLIZE_RE, md)
+        md.inlinePatterns.register(UrlizePattern(URLIZE_RE, md), "autolink", 120)
 
-def makeExtension(*args, **kwargs):
-    return UrlizeExtension(*args, **kwargs)
+def makeExtension(**kwargs):
+    return UrlizeExtension(**kwargs)
 
 if __name__ == "__main__":
     import doctest


### PR DESCRIPTION
Since Markdown 3.4, some stuff are no more supported.
Changelog: https://python-markdown.github.io/change_log/release-3.4/
Impact on the extension:

- md_globals argument isn't supported anymore;
- markdown.util.etree had been removed for xml.etree.ElementTree;
- to register an extension, we have to use Registry().register;
- support for Extension args had been deprecated and removed, only keyword arguments are now supported.